### PR TITLE
[PEDSP-3951] resque gem upgrade 2.4.0 -> 2.6.0 and rexml 3.2.5 -> 3.2.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
     redis-namespace (1.10.0)
       redis (>= 4)
     regexp_parser (2.6.1)
-    resque (2.4.0)
+    resque (2.6.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
       redis-namespace (~> 1.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,8 @@ GEM
       multi_json (~> 1.0)
       redis-namespace (~> 1.6)
       sinatra (>= 0.9.2)
-    rexml (3.2.5)
+    rexml (3.2.9)
+      strscan
     rubocop (1.41.1)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -54,6 +55,7 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.5)
       tilt (~> 2.0)
+    strscan (3.1.0)
     test-unit (3.5.7)
       power_assert
     tilt (2.0.11)


### PR DESCRIPTION
Fixes https://github.com/adgear/resque-lock/security/dependabot/6
Fixes https://github.com/adgear/resque-lock/security/dependabot/10