### PR TITLE
[PEDSP-20741] INF sec - update rack version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'rack', '>= 2.2.13'
 gem 'resque'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,4 +74,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.4.15
+   2.2.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     parser (3.2.0.0)
       ast (~> 2.4.1)
     power_assert (2.0.3)
-    rack (2.2.9)
+    rack (2.2.17)
     rack-protection (3.0.5)
       rack
     rainbow (3.1.1)
@@ -66,6 +66,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  rack (>= 2.2.13)
   rake
   resque
   resque-lock!
@@ -73,4 +74,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.2.27
+   2.4.15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,4 +74,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.2.17
+   2.2.27


### PR DESCRIPTION
Update Rack version
closes : https://adgear.atlassian.net/browse/PEDSP-20741
[[INF-2826] [AppSec][Code] - 7 vulnerabilities found in dependencies within rtb-js - JIRA](https://adgear.atlassian.net/browse/INF-2826)

----
[INF-2826]: https://adgear.atlassian.net/browse/INF-2826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

bundle exec rake test
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#has_rdoc= called from /home/test/sm-wd/resque-lock/resque-lock.gemspec:12.
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#has_rdoc= called from /home/test/sm-wd/resque-lock/resque-lock.gemspec:12.
Loaded suite /home/test/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rake-13.0.6/lib/rake/rake_test_loader
Started
/home/test/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/resque-2.6.0/lib/resque.rb:141: warning: instance variable @data_store not initialized
....
Finished in 3.009621434 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------
4 tests, 7 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------
1.33 tests/s, 2.33 assertions/s