### PR TITLE
[PEDSP-20741] Update workflow to selfhosted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,9 @@ on:
 jobs:
   test:
     name: tests / ruby
-    runs-on: ubuntu-latest
+    runs-on:
+      group: SelfHostedDefault
+      labels: ubuntu-22.04-small
 
     services:
       redis:


### PR DESCRIPTION
Updated the runner to selfhosted Runner as ubuntu-latest is not supported
